### PR TITLE
refactor: consolidate CSS variables with Anthropic color palette

### DIFF
--- a/src/components/DarkLightThemeSwitch.astro
+++ b/src/components/DarkLightThemeSwitch.astro
@@ -55,7 +55,7 @@
     background: none;
   }
   .sun {
-    fill: black;
+    fill: var(--color-text);
   }
   .moon {
     fill: transparent;
@@ -65,6 +65,6 @@
     fill: transparent;
   }
   :global(.dark) .moon {
-    fill: white;
+    fill: var(--color-text);
   }
 </style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -27,13 +27,8 @@ import { SITE_TITLE } from "../const";
     padding: 2rem 1rem;
     margin-top: auto;
     width: 100%;
-    background-color: var(--secundary-color);
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
-  }
-
-  :global(.dark) footer {
-    background-color: var(--bg-color-dark);
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    background-color: var(--color-bg);
+    border-top: 1px solid color-mix(in srgb, var(--color-text) 10%, transparent);
   }
 
   .footer-container {
@@ -53,23 +48,18 @@ import { SITE_TITLE } from "../const";
   }
 
   .social-icon {
-    color: var(--main-color);
+    color: var(--color-text);
     transition: color 0.2s ease, transform 0.2s ease;
     display: flex;
     align-items: center;
     justify-content: center;
   }
 
-  :global(.dark) .social-icon {
-    color: var(--secundary-color);
-  }
-
   .social-icon svg {
     width: 1.5rem;
     height: 1.5rem;
   }
-  
-  /* Custom icons styling */
+
   .custom-icon {
     display: inline-flex;
     align-items: center;
@@ -77,30 +67,26 @@ import { SITE_TITLE } from "../const";
     width: 1.5rem;
     height: 1.5rem;
   }
-  
+
   .custom-icon svg {
     width: 100%;
     height: 100%;
   }
 
   .social-icon:hover {
-    color: var(--button-flat);
+    color: var(--color-accent);
     transform: translateY(-2px);
   }
 
   .social-icon:active {
-    color: var(--button-active);
+    color: var(--color-accent-active);
   }
 
   .footer-content {
     text-align: center;
     font-size: 0.9rem;
-    color: var(--main-color);
+    color: var(--color-text);
     opacity: 0.8;
-  }
-
-  :global(.dark) .footer-content {
-    color: var(--secundary-color);
   }
 
   .footer-content a {
@@ -110,7 +96,7 @@ import { SITE_TITLE } from "../const";
   }
 
   .footer-content a:hover {
-    color: var(--button-flat);
+    color: var(--color-accent);
     text-decoration: underline;
   }
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -184,12 +184,8 @@ const isActive = (path: string) => {
     font-weight: 700;
     font-size: 1.25rem;
     text-decoration: none;
-    color: var(--main-color);
+    color: var(--color-text);
     letter-spacing: -0.02em;
-  }
-
-  :global(.dark) .logo a {
-    color: var(--secundary-color);
   }
 
   .sr-only {
@@ -222,14 +218,10 @@ const isActive = (path: string) => {
   .nav-list a {
     position: relative;
     text-decoration: none;
-    color: var(--main-color);
+    color: var(--color-text);
     font-weight: 500;
     padding: 0.25rem 0;
     transition: color 0.2s ease;
-  }
-
-  :global(.dark) .nav-list a {
-    color: var(--secundary-color);
   }
 
   .nav-list a::after {
@@ -239,7 +231,7 @@ const isActive = (path: string) => {
     left: 0;
     width: 0;
     height: 2px;
-    background-color: var(--button-flat);
+    background-color: var(--color-accent);
     transition: width 0.2s ease;
   }
 
@@ -275,13 +267,9 @@ const isActive = (path: string) => {
   .bar {
     width: 100%;
     height: 2px;
-    background-color: var(--main-color);
+    background-color: var(--color-text);
     border-radius: 2px;
     transition: all 0.3s ease;
-  }
-
-  :global(.dark) .bar {
-    background-color: var(--secundary-color);
   }
 
   /* Mobile navigation */
@@ -300,20 +288,15 @@ const isActive = (path: string) => {
       right: 0;
       height: 100vh;
       width: 260px;
-      background-color: rgba(255, 255, 255, 0.97);
+      background-color: color-mix(in srgb, var(--color-bg) 97%, transparent);
       backdrop-filter: blur(10px);
       -webkit-backdrop-filter: blur(10px);
       transform: translateX(100%);
       transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
       padding: 5rem 2rem 2rem;
-      box-shadow: -5px 0 15px rgba(0, 0, 0, 0.05);
+      box-shadow: -5px 0 15px color-mix(in srgb, var(--color-text) 5%, transparent);
       z-index: 1000;
-      overflow-y: auto; /* Allow scrolling if menu is too tall */
-    }
-
-    :global(.dark) .primary-navigation {
-      background-color: rgba(24, 24, 27, 0.97);
-      box-shadow: -5px 0 15px rgba(0, 0, 0, 0.2);
+      overflow-y: auto;
     }
 
     .primary-navigation.show {
@@ -352,12 +335,12 @@ const isActive = (path: string) => {
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: color-mix(in srgb, var(--color-text) 50%, transparent);
     backdrop-filter: blur(3px);
     display: none;
     opacity: 0;
     transition: opacity 0.3s ease;
-    z-index: 990; /* Below the nav but above everything else */
+    z-index: 990;
   }
 
   .nav-backdrop.visible {

--- a/src/components/Links.astro
+++ b/src/components/Links.astro
@@ -54,7 +54,7 @@ import { links } from "../data";
     margin-top: 16px;
     font-weight: 500;
     a {
-      color: var(--text-color);
+      color: var(--color-text);
       text-decoration: underline;
     }
   }
@@ -70,8 +70,8 @@ import { links } from "../data";
     white-space: normal;
     padding: 1rem 2rem;
     width: 100%;
-    background-color: black;
-    color: white;
+    background-color: var(--color-text);
+    color: var(--color-bg);
     font-size: 16px;
     font-weight: 500;
     letter-spacing: 0.5px;
@@ -88,25 +88,15 @@ import { links } from "../data";
 
     &:hover {
       transform: scale(1.02);
-      background-color: rgb(0 0 0 / 0.8);
+      background-color: var(--color-accent);
     }
     &:active {
       transform: scale(1.02);
-      background-color: rgb(0 0 0 / 0.8);
+      background-color: var(--color-accent-active);
     }
     &:focus-visible {
-      outline: 3px solid #4d90fe;
+      outline: 3px solid var(--color-accent);
       outline-offset: 2px;
     }
-  }
-
-  :global(.dark) .link {
-    background: rgba(0, 0, 0, 1);
-    border: solid 2px rgba(0, 0, 0, 1);
-    color: white;
-  }
-  :global(.dark) .link:hover {
-    background: rgba(0, 0, 0, 0.8);
-    color: white;
   }
 </style>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,16 +1,19 @@
 :root {
-  --border-color: #9d70ff;
-  --button-active: #6a00ff;
-  --button-flat: #6a00ff;
-  --button-hover: #770fff;
-  --cards: #d8ccff;
-  --main-color: black;
-  --secundary-color: #f3f0ff;
-  --text-bold-color: #2b007a;
-  --text-secondary: #6b7280;
-  --text-highligth: #770fff;
-  /* Darkmode */
-  --bg-color-dark: #18181b;
+  /* Core palette - Anthropic inspired */
+  --color-accent: #CC785C;
+  --color-accent-hover: #b5694f;
+  --color-accent-active: #a35d46;
+  --color-text: #141413;
+  --color-text-muted: #828179;
+  --color-bg: #F0EFEA;
+  --color-bg-elevated: #FFFFFF;
+}
+
+.dark {
+  --color-text: #F0EFEA;
+  --color-text-muted: rgba(240, 239, 234, 0.7);
+  --color-bg: #1a1a19;
+  --color-bg-elevated: #242423;
 }
 
 *,
@@ -42,22 +45,15 @@ body {
     Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   font-size: 16px;
   line-height: 1.5;
-  color: var(--main-color);
-  background-color: #fff;
+  color: var(--color-text);
+  background-color: var(--color-bg);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeSpeed;
   scroll-behavior: smooth;
-  /* Improve performance on mobile */
   -webkit-tap-highlight-color: transparent;
-  /* Prevent content reflow */
   overflow-wrap: break-word;
   word-break: break-word;
-}
-
-.dark body {
-  background-color: var(--bg-color-dark);
-  color: var(--secundary-color);
 }
 
 main {

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -69,29 +69,19 @@ const formattedUpdatedDate = updatedDate?.toLocaleDateString("en-us", {
 </Layout>
 
 <style is:global>
-  /* Global styles for dark mode compatibility */
+  /* Prose variables - inherit from core palette via CSS variable swap */
   :root {
-    --prose-headings: var(--text-bold-color, #111827);
-    --prose-body: var(--main-color);
-    --prose-links: var(--button-flat);
-    --prose-links-hover: var(--button-hover);
-    --prose-borders: rgba(0, 0, 0, 0.1);
-    --prose-captions: var(--text-secondary, #6b7280);
-    --prose-code-bg: rgba(0, 0, 0, 0.05);
-    --prose-code-text: var(--text-bold-color, #111827);
-    --prose-pre-bg: rgb(31, 41, 55);
-    --prose-pre-text: rgb(229, 231, 235);
-    --prose-blockquote: var(--text-secondary, #6b7280);
-  }
-
-  .dark {
-    --prose-headings: var(--secundary-color);
-    --prose-body: var(--secundary-color);
-    --prose-borders: rgba(255, 255, 255, 0.1);
-    --prose-captions: rgba(255, 255, 255, 0.7);
-    --prose-code-bg: rgba(255, 255, 255, 0.1);
-    --prose-code-text: var(--secundary-color);
-    --prose-blockquote: rgba(255, 255, 255, 0.7);
+    --prose-headings: var(--color-text);
+    --prose-body: var(--color-text);
+    --prose-links: var(--color-accent);
+    --prose-links-hover: var(--color-accent-hover);
+    --prose-borders: color-mix(in srgb, var(--color-text) 10%, transparent);
+    --prose-captions: var(--color-text-muted);
+    --prose-code-bg: color-mix(in srgb, var(--color-text) 5%, transparent);
+    --prose-code-text: var(--color-text);
+    --prose-pre-bg: #1a1a19;
+    --prose-pre-text: #F0EFEA;
+    --prose-blockquote: var(--color-text-muted);
   }
 
   /* Container */
@@ -127,7 +117,7 @@ const formattedUpdatedDate = updatedDate?.toLocaleDateString("en-us", {
     max-height: 500px;
     object-fit: cover;
     border-radius: 0.375rem;
-    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 10px 25px -5px color-mix(in srgb, var(--color-text) 5%, transparent);
   }
 
   .post-title {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -61,7 +61,7 @@ const sortedPosts = posts.sort(
   }
 
   .description {
-    color: var(--text-secondary);
+    color: var(--color-text-muted);
     margin-bottom: 3rem;
   }
 
@@ -99,7 +99,7 @@ const sortedPosts = posts.sort(
 
   time {
     font-size: 0.85rem;
-    color: var(--text-secondary);
+    color: var(--color-text-muted);
   }
 
   .post-title {
@@ -123,7 +123,7 @@ const sortedPosts = posts.sort(
 
   .read-more {
     display: inline-block;
-    color: var(--accent);
+    color: var(--color-accent);
     text-decoration: none;
     font-weight: 500;
     align-self: flex-start;

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -92,15 +92,11 @@ import { SITE_TITLE } from "@/const";
   }
 
   .contact-method {
-    background-color: var(--secundary-color);
+    background-color: var(--color-bg-elevated);
     padding: 2rem;
     border-radius: 0.5rem;
     text-align: center;
     transition: transform 0.2s ease;
-  }
-
-  :global(.dark) .contact-method {
-    background-color: rgba(255, 255, 255, 0.05);
   }
 
   .contact-method:hover {
@@ -111,7 +107,7 @@ import { SITE_TITLE } from "@/const";
     width: 3rem;
     height: 3rem;
     margin: 0 auto 1rem;
-    color: var(--button-flat);
+    color: var(--color-accent);
   }
 
   .contact-method h2 {
@@ -125,15 +121,11 @@ import { SITE_TITLE } from "@/const";
   }
 
   .contact-link {
-    color: var(--button-flat);
+    color: var(--color-accent);
     text-decoration: none;
     font-weight: 500;
     transition: color 0.2s ease;
     display: inline-block;
-  }
-
-  :global(.dark) .contact-link {
-    color: white;
   }
 
   .contact-link:hover {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,18 +52,18 @@ const userDesc = userData[0].userDesc;
     margin: 1.5rem 0;
     line-height: 1.6;
     font-size: 1.1rem;
-    color: var(--text-color);
+    color: var(--color-text);
   }
 
   .bio a {
-    color: white;
+    color: var(--color-accent);
     font-weight: 600;
     text-decoration: underline;
     transition: color 0.2s ease;
   }
 
   .bio a:hover {
-    color: #ff6b61;
+    color: var(--color-accent-hover);
   }
 
   /* Improve mobile experience */


### PR DESCRIPTION
## Summary

- Consolidate 18+ duplicate CSS variables into 7 clean `--color-*` variables
- Implement CSS variable swap for automatic dark mode (single source of truth)
- Remove scattered `:global(.dark)` overrides across 6 components
- Fix typos in variable names (`secundary`, `highligth`)
- Use modern `color-mix()` for dynamic transparency effects

## New Variable Architecture

```css
:root {
  --color-accent: #CC785C;
  --color-accent-hover: #b5694f;
  --color-accent-active: #a35d46;
  --color-text: #141413;
  --color-text-muted: #828179;
  --color-bg: #F0EFEA;
  --color-bg-elevated: #FFFFFF;
}

.dark {
  --color-text: #F0EFEA;
  --color-text-muted: rgba(240, 239, 234, 0.7);
  --color-bg: #1a1a19;
  --color-bg-elevated: #242423;
}
```

## Files Changed

| File | Changes |
|------|---------|
| `src/css/styles.css` | New variable definitions |
| `src/layouts/BlogPost.astro` | Simplified prose variables |
| `src/components/Header.astro` | Removed dark mode overrides |
| `src/components/Footer.astro` | Removed dark mode overrides |
| `src/components/Links.astro` | Removed dark mode overrides |
| `src/components/DarkLightThemeSwitch.astro` | Uses new variables |
| `src/pages/*.astro` | Updated variable references |

## Test plan

- [ ] Verify light mode displays correctly
- [ ] Verify dark mode displays correctly (toggle switch)
- [ ] Check all pages: Home, Blog, Blog Post, Contact
- [ ] Test mobile navigation menu styling
- [ ] Verify hover/active states on buttons and links

🤖 Generated with [Claude Code](https://claude.com/claude-code)